### PR TITLE
allow package managment in cloud-init by default

### DIFF
--- a/cloud-init-rhel.cfg
+++ b/cloud-init-rhel.cfg
@@ -24,6 +24,8 @@ cloud_init_modules:
 
 cloud_config_modules:
  - mounts
+ - yum-add-repo
+ - package-update-upgrade-install
  - locale
  - set-passwords
  - timezone


### PR DESCRIPTION
This enables the "yum-add-repo" and "package-update-upgrade-install"
modules in /etc/cloud.cfg, which permits people to install new yum
repositories and packages via the cloud-config mechanism:

```
packages:
 - vim-enhanced
 - git
```

These are not enabled by default which can be confusing to people trying to install packages using the examples in the documentation.
